### PR TITLE
Fix Spotify session timer not advancing to next track

### DIFF
--- a/script.js
+++ b/script.js
@@ -1580,7 +1580,6 @@ document.addEventListener("DOMContentLoaded", async () => {
             .catch((e) =>
               console.error("[Spotify FadeOut] Error getVolume:", e),
             );
-          return; // Salir de la lógica síncrona para Spotify fadeOut
         } else {
           currentVolume = 0;
           volumeStep = 0;


### PR DESCRIPTION
## Summary
- ensure the Spotify fade-out logic does not abort before scheduling the gap timer
- allow session timers to advance to the next track after the configured delay

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_6907cc7e64388320a77a20162a8c7813