### PR TITLE
Adjust playlist source spacing

### DIFF
--- a/style.css
+++ b/style.css
@@ -102,6 +102,7 @@ select {
 input[type="number"] { text-align: right; padding-right: 10px;}
 input[type="text"], input[type="number"] { cursor: text; } /* Cursor normal para inputs */
 .playlist-buttons { display: flex; flex-direction: column; gap: 10px; }
+.playlist-source-selector { display: flex; flex-direction: column; gap: 8px; margin-top: 8px; }
 /* Ocultar input file */
 #add-mp3-input { display: none; }
 /* Hacer que el label parezca un botón */


### PR DESCRIPTION
### Motivation
- Slightly increase the vertical spacing between the playlist buttons / Spotify connect button and the "Origen de la playlist actual" label/select so it matches the spacing used by other config groups such as `Segmento de Canción`.

### Description
- Add a small CSS rule in `style.css`: `.playlist-source-selector { display: flex; flex-direction: column; gap: 8px; margin-top: 8px; }` to space the label/select and separate the block from the buttons.

### Testing
- Started a local server with `python -m http.server 8000` and captured a full-page screenshot using Playwright pointed at `http://127.0.0.1:8000/index.html`, which completed successfully and produced `artifacts/playlist-spacing.png`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69825b601888832089f76e700dda4e44)